### PR TITLE
Refactor database configuration handling

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,8 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
-    </startup>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+  </startup>
+  <connectionStrings>
+    <add name="Users" connectionString="server=localhost;uid=dragnet;password=dragnet5;database=userdata" providerName="MySql.Data.MySqlClient" />
+    <add name="Control" connectionString="server=localhost;uid=dragnet;password=dragnet5;database=dragnetcontrol" providerName="MySql.Data.MySqlClient" />
+    <add name="Dragnet" connectionString="server=localhost;uid=dragnet;password=dragnet5;database=dragnet" providerName="MySql.Data.MySqlClient" />
+    <add name="Asset" connectionString="server=localhost;uid=dragnet;password=dragnet5;database=assetdata" providerName="MySql.Data.MySqlClient" />
+    <add name="News" connectionString="server=localhost;uid=dragnet;password=dragnet5;database=newsdata" providerName="MySql.Data.MySqlClient" />
+  </connectionStrings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/AssetDBEdit.cs
+++ b/AssetDBEdit.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using MySqlConnector;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
@@ -27,7 +28,7 @@ namespace DragnetControl
 
         private void SaveButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 try
                 {
@@ -75,7 +76,7 @@ namespace DragnetControl
 
         private void SaveandCloseButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;

--- a/AssetLoadingScreen.cs
+++ b/AssetLoadingScreen.cs
@@ -1,4 +1,5 @@
-﻿using MySqlConnector;
+using MySqlConnector;
+using DragnetControl.Infrastructure.Configuration;
 
 
 namespace DragnetControl
@@ -20,7 +21,8 @@ namespace DragnetControl
 
         private void LoadUserSettings()
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            var databaseSettings = DatabaseSettings.Current;
+            using (MySqlConnection conn = new MySqlConnection(databaseSettings.UsersConnectionString))
             {
                 try
                 {
@@ -280,10 +282,6 @@ namespace DragnetControl
                                     GlobalVariables.ActiveLLMPromptVersion = reader.GetString("LLMPromptVersion");
                                     StatusLabel.Text = "Loading Active LLM Prompt Configuration: LLMPromptVersion";
 
-                                    GlobalVariables.DragnetDBConnect = $"server={GlobalVariables.DragnetDBIP};uid={GlobalVariables.DragnetDBUser};password={GlobalVariables.DragnetDBPassword};database={GlobalVariables.DragnetDBName}";
-                                    GlobalVariables.AssetDBConnect = $"server={GlobalVariables.assetIP};uid={GlobalVariables.assetUser};password={GlobalVariables.assetPW};database={GlobalVariables.assetDBName}";
-                                    GlobalVariables.NewsDBConnect = $"server={GlobalVariables.newsIP};uid={GlobalVariables.newsUser};password={GlobalVariables.newsPW};database=newsdata";
-                                    GlobalVariables.ControlDBConnect =$"server={GlobalVariables.DragnetControlIP};uid={GlobalVariables.DragnetControlUser};password={GlobalVariables.DragnetControlPassword};database={GlobalVariables.DragnetControlName}";
                                 }
                             }
                             else

--- a/Authentication.cs
+++ b/Authentication.cs
@@ -1,20 +1,25 @@
-﻿using System.Security.Cryptography;
+using System;
+using System.Security.Cryptography;
 using System.Text;
-using YourNamespace;
+using System.Windows.Forms;
+using DragnetControl.Infrastructure.Configuration;
 using MySqlConnector;
 
 namespace DragnetControl
 {
     public partial class Authentication : Form
     {
+        private readonly DatabaseSettings _databaseSettings;
+
         public Authentication()
+            : this(DatabaseSettings.Current)
         {
+        }
+
+        internal Authentication(DatabaseSettings databaseSettings)
+        {
+            _databaseSettings = databaseSettings ?? throw new ArgumentNullException(nameof(databaseSettings));
             InitializeComponent();
-            GlobalVariables.UsersDBIP = "localhost";
-            GlobalVariables.UsersDBUsername = "dragnet";
-            GlobalVariables.usersdbPW = "dragnet5";
-            GlobalVariables.UsersDBConnect =
-                $"server={GlobalVariables.UsersDBIP};uid={GlobalVariables.UsersDBUsername};password={GlobalVariables.usersdbPW};database=userdata";
         }
 
         private string passwordAttempt;
@@ -23,7 +28,7 @@ namespace DragnetControl
         {
             dbError = false;
 
-            using (var conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (var conn = new MySqlConnection(_databaseSettings.UsersConnectionString))
             {
                 try
                 {
@@ -112,7 +117,7 @@ namespace DragnetControl
         {
             try
             {
-                using (var conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+                using (var conn = new MySqlConnection(_databaseSettings.UsersConnectionString))
                 {
                     conn.Open();
                     toolStripStatusLabel1.ForeColor = System.Drawing.Color.Cyan;

--- a/BinanceScannerSetup.cs
+++ b/BinanceScannerSetup.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 using MySqlConnector;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
@@ -27,7 +28,7 @@ namespace DragnetControl
 
         private void SaveButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;
@@ -92,7 +93,7 @@ namespace DragnetControl
 
         private void SaveandCloseButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;

--- a/CoinbaseScannerSetup.cs
+++ b/CoinbaseScannerSetup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using MySqlConnector;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
@@ -34,7 +35,7 @@ namespace DragnetControl
 
         private void SaveButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;
@@ -101,7 +102,7 @@ namespace DragnetControl
 
         private void SaveandCloseButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;

--- a/CuratorSetup.cs
+++ b/CuratorSetup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using MySqlConnector;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
@@ -33,7 +34,7 @@ namespace DragnetControl
 
         private void SaveButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;
@@ -90,7 +91,7 @@ namespace DragnetControl
 
         private void SaveandCloseButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;

--- a/DragnetControl.csproj
+++ b/DragnetControl.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="OpenQA.Selenium.Chrome.ChromeDriverExtensions" Version="1.2.0" />
     <PackageReference Include="OxyPlot.WindowsForms" Version="2.2.0" />
     <PackageReference Include="WinForms.DataVisualization" Version="1.10.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DragnetDBEdit.cs
+++ b/DragnetDBEdit.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 using MySqlConnector;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
@@ -20,7 +21,7 @@ namespace DragnetControl
 
         private void SaveButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;
@@ -68,7 +69,7 @@ namespace DragnetControl
 
         private void SaveandCloseButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;

--- a/Gullveig.cs
+++ b/Gullveig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -12,6 +12,7 @@ using System.Windows.Forms;
 using System.Windows.Forms.DataVisualization.Charting;
 using System.Xml.Linq;
 using MySql.Data.MySqlClient;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
@@ -21,13 +22,13 @@ namespace DragnetControl
         {
             InitializeComponent();
             LoadBalanceOfPowerImages(pictureBoxHouse, pictureBoxSenate);
-            SearchPoliticians(GlobalVariables.AssetDBConnect, searchTextBox, politiciansListBox, representativesCheckBox, senatorsCheckBox, republicansCheckBox, democratCheckBox, otherCheckBox);
+            SearchPoliticians(DatabaseSettings.Current.AssetConnectionString, searchTextBox, politiciansListBox, representativesCheckBox, senatorsCheckBox, republicansCheckBox, democratCheckBox, otherCheckBox);
             
         }
 
         private void searchButton_Click(object sender, EventArgs e)
         {
-            SearchPoliticians(GlobalVariables.AssetDBConnect, searchTextBox, politiciansListBox, representativesCheckBox, senatorsCheckBox, republicansCheckBox, democratCheckBox, otherCheckBox);
+            SearchPoliticians(DatabaseSettings.Current.AssetConnectionString, searchTextBox, politiciansListBox, representativesCheckBox, senatorsCheckBox, republicansCheckBox, democratCheckBox, otherCheckBox);
         }
         private void SearchPoliticians(string connectionString, TextBox searchTextBox, ListBox listBox, CheckBox representativesCheckBox, CheckBox senatorsCheckBox, CheckBox republicanCheckBox, CheckBox democratCheckBox, CheckBox otherCheckBox)
         {
@@ -185,7 +186,7 @@ namespace DragnetControl
             if (politiciansListBox.SelectedIndex != -1)
             {
                 string selectedPolitician = politiciansListBox.SelectedItem.ToString();
-                using (MySqlConnection connection = new MySqlConnection(GlobalVariables.AssetDBConnect))
+                using (MySqlConnection connection = new MySqlConnection(DatabaseSettings.Current.AssetConnectionString))
                 {
                     string query = "SELECT * FROM politicians WHERE Name = @Name";
                     MySqlCommand cmd = new MySqlCommand(query, connection);
@@ -237,7 +238,7 @@ namespace DragnetControl
             string tableName = politicianName.ToLower().Replace(' ', '_');
             string query = $"SELECT issuer,publisheddate, tradeddate, daystofile, owner, type, size, price FROM Politicians.`{tableName}`";
 
-            using (MySqlConnection connection = new MySqlConnection(GlobalVariables.AssetDBConnect))
+            using (MySqlConnection connection = new MySqlConnection(DatabaseSettings.Current.AssetConnectionString))
             {
                 try
                 {

--- a/Infrastructure/Configuration/DatabaseSettings.cs
+++ b/Infrastructure/Configuration/DatabaseSettings.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Configuration;
+
+namespace DragnetControl.Infrastructure.Configuration
+{
+    /// <summary>
+    /// Centralizes database connection strings so that they are read once from configuration
+    /// and can be reused throughout the application without relying on scattered global state.
+    /// </summary>
+    public sealed class DatabaseSettings
+    {
+        private static readonly Lazy<DatabaseSettings> _instance =
+            new Lazy<DatabaseSettings>(() => new DatabaseSettings());
+
+        private DatabaseSettings()
+        {
+            UsersConnectionString = ReadConnectionString("Users");
+            ControlConnectionString = ReadConnectionString("Control");
+            DragnetConnectionString = ReadOptionalConnectionString("Dragnet") ?? ControlConnectionString;
+            AssetConnectionString = ReadConnectionString("Asset");
+            NewsConnectionString = ReadConnectionString("News");
+        }
+
+        public static DatabaseSettings Current => _instance.Value;
+
+        public string UsersConnectionString { get; }
+
+        public string ControlConnectionString { get; }
+
+        public string DragnetConnectionString { get; }
+
+        public string AssetConnectionString { get; }
+
+        public string NewsConnectionString { get; }
+
+        private static string ReadConnectionString(string name)
+        {
+            var settings = ConfigurationManager.ConnectionStrings[name];
+            if (settings == null || string.IsNullOrWhiteSpace(settings.ConnectionString))
+            {
+                throw new ConfigurationErrorsException(
+                    $"Connection string '{name}' is not configured in App.config.");
+            }
+
+            return settings.ConnectionString;
+        }
+
+        private static string? ReadOptionalConnectionString(string name)
+        {
+            var settings = ConfigurationManager.ConnectionStrings[name];
+            return string.IsNullOrWhiteSpace(settings?.ConnectionString)
+                ? null
+                : settings.ConnectionString;
+        }
+    }
+}

--- a/KrakenScannerSetup.cs
+++ b/KrakenScannerSetup.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 using MySqlConnector;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
@@ -25,7 +26,7 @@ namespace DragnetControl
 
         private void SaveButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;
@@ -90,7 +91,7 @@ namespace DragnetControl
 
         private void SaveandCloseButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;

--- a/MainControl.cs
+++ b/MainControl.cs
@@ -1,4 +1,5 @@
-﻿
+using DragnetControl.Infrastructure.Configuration;
+
 using LiveChartsCore;
 using LiveChartsCore.SkiaSharpView;
 using Microsoft.VisualBasic.Devices;
@@ -416,7 +417,7 @@ namespace DragnetControl
             (int cpuscore, int ramscore) = GetResourceScores();
             bool enabled = true;
 
-            using (var conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+            using (var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
             {
                 conn.Open();
 
@@ -486,7 +487,7 @@ namespace DragnetControl
             Setup_Host_Node();
             tabControl1.TabPages.Clear();
 
-            using var conn = new MySqlConnection(GlobalVariables.ControlDBConnect);
+            using var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString);
             try
             {
                 conn.Open();
@@ -605,7 +606,7 @@ namespace DragnetControl
                 int newRamScore = int.TryParse(ramScoreBox.SelectedItem?.ToString(), out var r) ? r : 0;
                 bool newEnabled = enabledBox.Checked;
 
-                using (var conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+                using (var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
                 {
                     conn.Open();
                     string sql = @"UPDATE dragnet_nodes SET
@@ -827,7 +828,7 @@ namespace DragnetControl
         {
             string query = "SELECT status FROM dragnet_nodes WHERE ip_address = @ip";
 
-            using var conn = new MySqlConnection(GlobalVariables.ControlDBConnect);
+            using var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString);
             conn.Open();
 
             using var cmd = new MySqlCommand(query, conn);
@@ -841,7 +842,7 @@ namespace DragnetControl
         }
         private void LoadCryptoAssetDatabase()
         {
-            var conn = new MySqlConnection(GlobalVariables.AssetDBConnect);
+            var conn = new MySqlConnection(DatabaseSettings.Current.AssetConnectionString);
             string query = "SELECT * FROM assets.crypto";
             adapter = new MySqlDataAdapter(query, conn);
             MySqlCommandBuilder builder = new MySqlCommandBuilder(adapter);
@@ -946,7 +947,7 @@ namespace DragnetControl
             DataTable dt = new DataTable();
             try
             {
-                using (MySqlConnection conn = new MySqlConnection(GlobalVariables.DragnetDBConnect))
+                using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.DragnetConnectionString))
                 {
                     conn.Open();
                     string query = "SHOW TABLES;";
@@ -1016,7 +1017,7 @@ namespace DragnetControl
         private void autoDelegateButton_Click(object sender, EventArgs e)
         {
             WipeDragnetControlTables();
-            using (var conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+            using (var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
             {
                 conn.Open();
                 var cmd = new MySqlCommand("SELECT ip_address, username, password, port, enabled FROM dragnet_nodes", conn);
@@ -1081,7 +1082,7 @@ namespace DragnetControl
                 }
             }
             System.Threading.Thread.Sleep(3000);
-            using (var conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+            using (var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
             {
                 conn.Open();
                 var cmd = new MySqlCommand("SELECT ip_address, hostname, cpu_score, ram_score FROM dragnet_nodes", conn);
@@ -1150,7 +1151,7 @@ namespace DragnetControl
             }
             // Step 2: Retrieve all assets
             List<string> assetNames = new List<string>();
-            using (var assetConn = new MySqlConnection(GlobalVariables.AssetDBConnect))
+            using (var assetConn = new MySqlConnection(DatabaseSettings.Current.AssetConnectionString))
             {
                 assetConn.Open();
                 using var assetCmd = new MySqlCommand("SELECT name FROM crypto ORDER BY name ASC;", assetConn);
@@ -1201,7 +1202,7 @@ namespace DragnetControl
             double cryptoDelay = 1.0 / ((coinbaseQps * safety) / Math.Max(1, activeCryptoScanners));
 
             // --- Update users table (example: set for current/active user, or for all) ---
-            using (var userConn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (var userConn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 userConn.Open();
                 // Update CryptoDelay
@@ -1436,7 +1437,7 @@ namespace DragnetControl
             float cryptoDelay = GlobalVariables.CryptoDelay;
 
 
-            using (var userConn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (var userConn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 userConn.Open();
                 var cmd = new MySqlCommand("SELECT CryptoDelay FROM users WHERE username = @username LIMIT 1", userConn);
@@ -1746,7 +1747,7 @@ namespace DragnetControl
             string ip = tabText.Substring(parenStart + 1, parenEnd - parenStart - 1).Trim();
 
             // 4. Delete from database
-            using (var conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+            using (var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
             {
                 conn.Open();
                 string sql = "DELETE FROM dragnet_nodes WHERE ip_address = @ip";
@@ -1771,7 +1772,7 @@ namespace DragnetControl
             DataTable dt = new DataTable();
             try
             {
-                using (MySqlConnection conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+                using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
                 {
                     conn.Open();
                     string query = "SELECT * FROM dragnet_locks ORDER BY asset_name;";
@@ -1803,7 +1804,7 @@ namespace DragnetControl
             DataTable dt = new DataTable();
             try
             {
-                using (MySqlConnection conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+                using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
                 {
                     conn.Open();
                     string query = "SELECT curator_id, node_ip, asset_range_start, asset_range_end, status, last_heartbeat FROM curator_modules ORDER BY node_ip;";
@@ -1853,7 +1854,7 @@ namespace DragnetControl
             DataTable dt = new DataTable();
             try
             {
-                using (MySqlConnection conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+                using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
                 {
                     conn.Open();
                     string query = "SELECT scanner_id, node_ip, asset_range_start, asset_range_end, status, last_heartbeat FROM scanner_modules ORDER BY node_ip;";
@@ -1905,7 +1906,7 @@ namespace DragnetControl
             DataTable dt = new DataTable();
             try
             {
-                using (MySqlConnection conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+                using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
                 {
                     conn.Open();
                     string query = "SELECT Obscanner_id, node_ip, asset_range_start, asset_range_end, status, last_heartbeat FROM orderbook_modules ORDER BY node_ip;";
@@ -1956,7 +1957,7 @@ namespace DragnetControl
             DataTable dt = new DataTable();
             try
             {
-                using (MySqlConnection conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+                using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
                 {
                     conn.Open();
                     string query = "SELECT newsscraper_id, node_ip, asset_range_start, asset_range_end, status, last_heartbeat FROM newsscraper_modules ORDER BY node_ip;";
@@ -1995,7 +1996,7 @@ namespace DragnetControl
             DataTable dt = new DataTable();
             try
             {
-                using (MySqlConnection conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+                using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
                 {
                     conn.Open();
                     string query = "SELECT telegramscanner_id, node_ip, asset_range_start, asset_range_end, status, last_heartbeat FROM telegramscanner_modules ORDER BY node_ip;";
@@ -2034,7 +2035,7 @@ namespace DragnetControl
             DataTable dt = new DataTable();
             try
             {
-                using (MySqlConnection conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+                using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
                 {
                     conn.Open();
                     string query = "SELECT daemon_id, node_ip, status, last_heartbeat FROM daemon_modules ORDER BY node_ip;";
@@ -2110,7 +2111,7 @@ namespace DragnetControl
             DataTable dt = new DataTable();
             try
             {
-                using (MySqlConnection conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+                using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
                 {
                     conn.Open();
                     string query = "SELECT * FROM module_logs ORDER BY timestamp;";
@@ -2159,7 +2160,7 @@ namespace DragnetControl
 
             try
             {
-                using (MySqlConnection conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+                using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
                 {
                     conn.Open();
                     foreach (string table in tables)
@@ -2210,7 +2211,7 @@ namespace DragnetControl
 
         private void LoadDragnetTable(string tableName)
         {
-            var conn = new MySqlConnection(GlobalVariables.DragnetDBConnect);
+            var conn = new MySqlConnection(DatabaseSettings.Current.DragnetConnectionString);
             string query = $"SELECT * FROM `{tableName}` ORDER BY timestamp DESC LIMIT 33";
             dragnetAdapter = new MySqlDataAdapter(query, conn);
             dragnetBuilder = new MySqlCommandBuilder(dragnetAdapter);
@@ -2247,7 +2248,7 @@ namespace DragnetControl
 
             if (confirmResult != DialogResult.Yes) return;
 
-            using (var conn = new MySqlConnection(GlobalVariables.DragnetDBConnect))
+            using (var conn = new MySqlConnection(DatabaseSettings.Current.DragnetConnectionString))
             {
                 conn.Open();
                 int updateCount = 0;
@@ -2337,7 +2338,7 @@ namespace DragnetControl
         {
             List<string> nodeIPs = new List<string>();
 
-            using (var conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+            using (var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
             {
                 conn.Open();
                 string sql = "SELECT ip_address FROM dragnet_nodes WHERE enabled = 1;";
@@ -2487,7 +2488,7 @@ namespace DragnetControl
             sb.Append("]");
             string calendarDatesJson = sb.ToString();
 
-            using (var conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+            using (var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
             {
                 conn.Open();
                 string query = @"
@@ -2516,7 +2517,7 @@ namespace DragnetControl
 
             DataTable table = new DataTable();
 
-            using (var conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+            using (var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
             {
                 conn.Open();
 
@@ -2632,7 +2633,7 @@ namespace DragnetControl
             if (result != DialogResult.Yes)
                 return;
 
-            using (var conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+            using (var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
             {
                 conn.Open();
                 string query = @"DELETE FROM dragnet_schedule WHERE script_type = @type AND trigger_time = @time LIMIT 1;";
@@ -2827,7 +2828,7 @@ namespace DragnetControl
         private List<ScheduleRow> LoadScheduleRows()
         {
             var list = new List<ScheduleRow>();
-            using var conn = new MySqlConnection(GlobalVariables.ControlDBConnect);
+            using var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString);
             conn.Open();
             const string sql = "SELECT script_type, trigger_time, days_of_week, calendar_dates FROM dragnet_schedule;";
             using var cmd = new MySqlCommand(sql, conn);
@@ -2991,7 +2992,7 @@ namespace DragnetControl
 
             async Task SaveGlobalsToDbAsync(string hostVal, string portVal, string modelVal, int context)
             {
-                using var cn = new MySql.Data.MySqlClient.MySqlConnection(GlobalVariables.UsersDBConnect);
+                using var cn = new MySql.Data.MySqlClient.MySqlConnection(DatabaseSettings.Current.UsersConnectionString);
                 await cn.OpenAsync();
 
                 // Update by username; insert if not present
@@ -3237,7 +3238,7 @@ ORDER BY name ASC, updated_at DESC;";
 
             var where = string.IsNullOrWhiteSpace(filter) ? "" : "WHERE name LIKE @q OR version LIKE @q";
 
-            using var cn = new MySqlConnection(GlobalVariables.ControlDBConnect);
+            using var cn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString);
             await cn.OpenAsync();
             using var cmd = new MySqlCommand(sqlBase.Replace("/**where**/", where), cn);
             if (!string.IsNullOrWhiteSpace(filter))
@@ -3287,7 +3288,7 @@ FROM dragnetcontrol.prompt_registry
 WHERE name=@n AND version=@v
 LIMIT 1;";
 
-            using var cn = new MySqlConnection(GlobalVariables.ControlDBConnect);
+            using var cn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString);
             await cn.OpenAsync();
             using var cmd = new MySqlCommand(sql, cn);
             cmd.Parameters.AddWithValue("@n", it.Name);
@@ -3324,7 +3325,7 @@ FROM dragnetcontrol.prompt_registry
 WHERE name=@n AND version=@v
 LIMIT 1;";
 
-            using var cn = new MySqlConnection(GlobalVariables.ControlDBConnect);
+            using var cn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString);
             await cn.OpenAsync();
             using var cmd = new MySqlCommand(sql, cn);
             cmd.Parameters.AddWithValue("@n", name);
@@ -3372,7 +3373,7 @@ ON DUPLICATE KEY UPDATE
   created_by  = VALUES(created_by),
   updated_at  = CURRENT_TIMESTAMP;";
 
-            using var cn = new MySqlConnection(GlobalVariables.ControlDBConnect);
+            using var cn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString);
             await cn.OpenAsync();
             using var tx = await cn.BeginTransactionAsync();
 
@@ -3436,7 +3437,7 @@ ON DUPLICATE KEY UPDATE
             if (confirm != DialogResult.OK) return;
 
             const string sql = @"DELETE FROM dragnetcontrol.prompt_registry WHERE name=@n AND version=@v;";
-            using var cn = new MySqlConnection(GlobalVariables.ControlDBConnect);
+            using var cn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString);
             await cn.OpenAsync();
             using var cmd = new MySqlCommand(sql, cn);
             cmd.Parameters.AddWithValue("@n", name);
@@ -3489,7 +3490,7 @@ LIMIT 1;";
 
             try
             {
-                using var cn = new MySql.Data.MySqlClient.MySqlConnection(GlobalVariables.UsersDBConnect);
+                using var cn = new MySql.Data.MySqlClient.MySqlConnection(DatabaseSettings.Current.UsersConnectionString);
                 await cn.OpenAsync();
 
                 using var cmd = new MySql.Data.MySqlClient.MySqlCommand(updateSql, cn)

--- a/ManageAssets.cs
+++ b/ManageAssets.cs
@@ -3,22 +3,19 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using MySqlConnector;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
     public partial class ManageAssets : Form
     {
-        string AssetDBConnect = $"server={GlobalVariables.assetIP};uid={GlobalVariables.assetUser};pwd={GlobalVariables.assetPW};database={GlobalVariables.assetDBName}";
-
         public ManageAssets()
         {
             InitializeComponent();
-            using (MySqlConnection connection = new MySqlConnection(AssetDBConnect))
+            var assetDbConnect = DatabaseSettings.Current.AssetConnectionString;
+            using (MySqlConnection connection = new MySqlConnection(assetDbConnect))
             {
                 MySqlCommand command = new MySqlCommand("SELECT asset, commonname, market, active FROM stocks ORDER BY asset ASC", connection);
                 DataTable dataTable = new DataTable();

--- a/ModifyNode.cs
+++ b/ModifyNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using MySql.Data.MySqlClient;
 using Org.BouncyCastle.Asn1.Mozilla;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
@@ -53,7 +54,7 @@ namespace DragnetControl
             }
 
             // Check for existing IP
-            using (var conn = new MySqlConnection(GlobalVariables.ControlDBConnect))
+            using (var conn = new MySqlConnection(DatabaseSettings.Current.ControlConnectionString))
             {
                 conn.Open();
                 string checkSql = "SELECT COUNT(*) FROM dragnet_nodes WHERE ip_address = @ip";

--- a/Program.cs
+++ b/Program.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using MySql.Data.MySqlClient;
+using System.Configuration;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
@@ -17,6 +15,20 @@ namespace DragnetControl
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+            try
+            {
+                _ = DatabaseSettings.Current;
+            }
+            catch (ConfigurationErrorsException ex)
+            {
+                MessageBox.Show(
+                    $"Unable to load database configuration.\n\n{ex.Message}",
+                    "Configuration Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return;
+            }
+
             Application.Run(new Authentication());
         }
     }

--- a/TelegramScannerSetup.cs
+++ b/TelegramScannerSetup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using MySqlConnector;
+using DragnetControl.Infrastructure.Configuration;
 
 namespace DragnetControl
 {
@@ -29,7 +30,7 @@ namespace DragnetControl
 
         private void SaveButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;
@@ -84,7 +85,7 @@ namespace DragnetControl
 
         private void SaveandCloseButton_Click(object sender, EventArgs e)
         {
-            using (MySqlConnection conn = new MySqlConnection(GlobalVariables.UsersDBConnect))
+            using (MySqlConnection conn = new MySqlConnection(DatabaseSettings.Current.UsersConnectionString))
             {
                 int port1;
                 int port2;


### PR DESCRIPTION
## Summary
- add connection string definitions for each database to App.config and reference them via a new DatabaseSettings helper
- load database settings at application startup and resolve the authentication connection through the helper instead of hard-coded globals
- update WinForms code to consume DatabaseSettings connection strings rather than mutating GlobalVariables values

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d97806a483318bf8790c2a935bda