### PR TITLE
Fix configuration bootstrap and password change flow

### DIFF
--- a/Authentication.cs
+++ b/Authentication.cs
@@ -1,7 +1,10 @@
-﻿using System.Security.Cryptography;
+using System;
+using System.Security.Cryptography;
 using System.Text;
+using System.Windows.Forms;
 using DragnetControl.Configuration;
 using MySqlConnector;
+using BCryptNet = BCrypt.Net.BCrypt;
 
 namespace DragnetControl
 {
@@ -17,108 +20,91 @@ namespace DragnetControl
             InitializeComponent();
         }
 
-        private string passwordAttempt;
-
         private bool CheckCredentials(string username, string passwordAttempt, out bool dbError, out int accountStatus)
         {
             dbError = false;
             accountStatus = 0;
 
-            using (var conn = new MySqlConnection(_configuration.UsersDatabase.BuildConnectionString()))
+            using var conn = new MySqlConnection(_configuration.UsersDatabase.BuildConnectionString());
+            try
             {
-                try
+                conn.Open();
+
+                const string query = "SELECT * FROM users WHERE username = @username";
+                using var cmd = new MySqlCommand(query, conn);
+                cmd.Parameters.AddWithValue("@username", username);
+
+                using var reader = cmd.ExecuteReader();
+                if (!reader.HasRows)
                 {
-                    conn.Open();
-
-                    const string query = "SELECT * FROM users WHERE username = @username";
-                    using (var cmd = new MySqlCommand(query, conn))
-                    {
-                        // BUGFIX: bind the method parameter, not the global
-                        cmd.Parameters.AddWithValue("@username", username);
-
-                        using (var reader = cmd.ExecuteReader())
-                        {
-                            if (!reader.HasRows)
-                                return false;
-
-                            reader.Read();
-                            string storedPasswordHash = reader.GetString("password");
-
-                            // If not a BCrypt hash, treat as legacy/unsalted
-                            if (IsUnsaltedPassword(storedPasswordHash))
-                            {
-                                // If your legacy was plaintext:
-                                if (storedPasswordHash == passwordAttempt)
-                                {
-                                    // Force password change
-                                    using (var changePasswordForm = new PasswordChangeForm(username))
-                                    {
-                                        changePasswordForm.ShowDialog();
-                                    }
-                                    accountStatus = reader.GetInt32("accountstatus");
-                                    return true;
-                                }
-
-                                return false;
-                            }
-                            else
-                            {
-                                // BCrypt verification
-                                bool ok = BCrypt.Net.BCrypt.Verify(passwordAttempt, storedPasswordHash);
-                                if (ok)
-                                {
-                                    accountStatus = reader.GetInt32("accountstatus");
-                                    return true;
-                                }
-                                return false;
-                            }
-                        }
-                    }
+                    return false;
                 }
-                catch (MySqlException ex)
-                {
-                    dbError = true;
 
-                    // POPUP on login attempt failure due to DB connectivity (or any MySQL error)
-                    MessageBox.Show(
-                        "Unable to connect to the Users database.\n\nDetails:\n" + ex.Message,
-                        "Database Connection Error",
-                        MessageBoxButtons.OK,
-                        MessageBoxIcon.Error
-                    );
+                reader.Read();
+                var storedPasswordHash = reader.GetString("password");
+
+                if (IsUnsaltedPassword(storedPasswordHash))
+                {
+                    if (VerifyUnsaltedPassword(passwordAttempt, storedPasswordHash))
+                    {
+                        using var changePasswordForm = new PasswordChangeForm(username, _configuration.UsersDatabase);
+                        changePasswordForm.ShowDialog();
+                        accountStatus = reader.GetInt32("accountstatus");
+                        return true;
+                    }
 
                     return false;
                 }
+
+                var isValid = BCryptNet.Verify(passwordAttempt, storedPasswordHash);
+                if (isValid)
+                {
+                    accountStatus = reader.GetInt32("accountstatus");
+                }
+
+                return isValid;
             }
-        }
-
-        // Helper: consider non-BCrypt (not $2*) and not length 60 as "unsalted/legacy"
-        private bool IsUnsaltedPassword(string storedPassword)
-        {
-            return !storedPassword.StartsWith("$2") || storedPassword.Length != 60;
-        }
-
-        private bool VerifyUnsaltedPassword(string passwordAttempt, string storedPassword)
-        {
-            using (MD5 md5 = MD5.Create())
+            catch (MySqlException ex)
             {
-                byte[] inputBytes = Encoding.ASCII.GetBytes(passwordAttempt);
-                byte[] hashBytes = md5.ComputeHash(inputBytes);
-                string hash = BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
-                return hash == storedPassword;
+                dbError = true;
+
+                MessageBox.Show(
+                    "Unable to connect to the Users database.\n\nDetails:\n" + ex.Message,
+                    "Database Connection Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+
+                return false;
             }
+        }
+
+        private static bool IsUnsaltedPassword(string storedPassword)
+        {
+            return !storedPassword.StartsWith("$2", StringComparison.Ordinal) || storedPassword.Length != 60;
+        }
+
+        private static bool VerifyUnsaltedPassword(string passwordAttempt, string storedPassword)
+        {
+            if (storedPassword.Equals(passwordAttempt, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            using var md5 = MD5.Create();
+            var inputBytes = Encoding.ASCII.GetBytes(passwordAttempt);
+            var hashBytes = md5.ComputeHash(inputBytes);
+            var hash = BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
+            return hash == storedPassword.ToLowerInvariant();
         }
 
         private void Authentication_Load(object sender, EventArgs e)
         {
             try
             {
-                using (var conn = new MySqlConnection(_configuration.UsersDatabase.BuildConnectionString()))
-                {
-                    conn.Open();
-                    toolStripStatusLabel1.ForeColor = System.Drawing.Color.Cyan;
-                    toolStripStatusLabel1.Text = "User Database Connection Established";
-                }
+                using var conn = new MySqlConnection(_configuration.UsersDatabase.BuildConnectionString());
+                conn.Open();
+                toolStripStatusLabel1.ForeColor = System.Drawing.Color.Cyan;
+                toolStripStatusLabel1.Text = "User Database Connection Established";
             }
             catch (MySqlException)
             {
@@ -129,20 +115,16 @@ namespace DragnetControl
 
         private void LoginButton_Click(object sender, EventArgs e)
         {
-            string username = UsernameBox.Text;
-            passwordAttempt = PasswordBox.Text;
+            var username = UsernameBox.Text;
+            var passwordAttempt = PasswordBox.Text;
 
-            bool dbError;
-            int accountStatus;
-            bool ok = CheckCredentials(username, passwordAttempt, out dbError, out accountStatus);
+            var ok = CheckCredentials(username, passwordAttempt, out var dbError, out var accountStatus);
 
             if (dbError)
             {
-                // We already showed a MessageBox in CheckCredentials.
-                // Make the UI reflect the failure state:
                 InformationLabel.ForeColor = System.Drawing.Color.Red;
                 InformationLabel.Text = "Database connection failed.";
-                PasswordBox.Text = "";
+                PasswordBox.Text = string.Empty;
                 return;
             }
 
@@ -152,41 +134,41 @@ namespace DragnetControl
                 {
                     InformationLabel.ForeColor = System.Drawing.Color.Red;
                     InformationLabel.Text = "Account Locked/Suspended.";
-                    PasswordBox.Text = "";
+                    PasswordBox.Text = string.Empty;
+                    return;
                 }
-                else if (accountStatus == 1 || accountStatus == 2)
+
+                if (accountStatus == 1 || accountStatus == 2)
                 {
                     InformationLabel.ForeColor = System.Drawing.Color.Black;
                     InformationLabel.Text = "Login Successful. Loading configuration files.";
-                    PasswordBox.Text = "";
+                    PasswordBox.Text = string.Empty;
                     AccessRequestLabel.Hide();
-                    this.Hide();
+                    Hide();
 
-                    using (var assetLoad = new AssetLoadingScreen(_configurationLoader, username))
+                    using var assetLoad = new AssetLoadingScreen(_configurationLoader, username);
+                    assetLoad.ShowDialog();
+                    if (assetLoad.DialogResult == DialogResult.OK)
                     {
-                        assetLoad.ShowDialog();
-                        if (assetLoad.DialogResult == DialogResult.OK)
-                        {
-                            var sessionState = assetLoad.SessionState;
-                            GlobalVariables.Initialize(_configuration, sessionState);
-                            FormManager.Configure(() => new MainControl());
-                            var mainControl = FormManager.MainControl;
-                            mainControl.FormClosed += MainControl_FormClosed;
-                            mainControl.Show();
-                        }
-                        else
-                        {
-                            Show();
-                        }
+                        var sessionState = assetLoad.SessionState;
+                        GlobalVariables.Initialize(_configuration, sessionState);
+                        FormManager.Configure(() => new MainControl());
+                        var mainControl = FormManager.MainControl;
+                        mainControl.FormClosed += MainControl_FormClosed;
+                        mainControl.Show();
+                    }
+                    else
+                    {
+                        Show();
                     }
                 }
+
+                return;
             }
-            else
-            {
-                InformationLabel.ForeColor = System.Drawing.Color.Red;
-                InformationLabel.Text = "Invalid username or password.";
-                PasswordBox.Text = "";
-            }
+
+            InformationLabel.ForeColor = System.Drawing.Color.Red;
+            InformationLabel.Text = "Invalid username or password.";
+            PasswordBox.Text = string.Empty;
         }
 
         private void ExitButton_Click(object sender, EventArgs e)
@@ -194,20 +176,21 @@ namespace DragnetControl
             Application.Exit();
         }
 
-        private void MainControl_FormClosed(object sender, FormClosedEventArgs e)
+        private void MainControl_FormClosed(object? sender, FormClosedEventArgs e)
         {
             if (RememberUserNameCheckBox.Checked)
             {
-                PasswordBox.Text = "";
+                PasswordBox.Text = string.Empty;
             }
             else
             {
-                UsernameBox.Text = "";
-                PasswordBox.Text = "";
+                UsernameBox.Text = string.Empty;
+                PasswordBox.Text = string.Empty;
             }
+
             InformationLabel.Text = "Enter Credentials:";
             AccessRequestLabel.Show();
-            this.Show();
+            Show();
         }
 
         private void ConnectionStatusStrip_ItemClicked(object sender, ToolStripItemClickedEventArgs e)

--- a/Configuration/ConfigurationLoader.cs
+++ b/Configuration/ConfigurationLoader.cs
@@ -1,9 +1,8 @@
-﻿using MySqlX.XDevAPI;
-using MySqlConnector;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using MySqlConnector;
 
 namespace DragnetControl.Configuration
 {
@@ -21,263 +20,265 @@ namespace DragnetControl.Configuration
             IProgress<ConfigurationProgress>? progress = null,
             CancellationToken cancellationToken = default)
         {
-                if (string.IsNullOrWhiteSpace(username))
-                    {
-        throw new ArgumentException("Username must be supplied", nameof(username));
-                    }
-    
-    var sessionState = new RuntimeSessionState(username)
-                {
-        UsersDbConnectionString = _configuration.UsersDatabase.BuildConnectionString()
-                    }
-    ;
-    
-    var milestones = new Queue<(string Message, int Progress)>(new[]
-                {
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                throw new ArgumentException("Username must be supplied", nameof(username));
+            }
+
+            var sessionState = new RuntimeSessionState(username)
+            {
+                UsersDbConnectionString = _configuration.UsersDatabase.BuildConnectionString()
+            };
+
+            var milestones = new Queue<(string Message, int Progress)>(new[]
+            {
                 ("Opening user database", 10),
                 ("Loading user profile", 30),
                 ("Loading database credentials", 60),
-                        ("Loading integrations", 90),
+                ("Loading integrations", 90),
                 ("Finishing", 100)
             });
-    
-    progress?.Report(new ConfigurationProgress("Preparing to load user profile", 0));
-    
-    await using var connection = new MySqlConnection(sessionState.UsersDbConnectionString);
-    await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-    ReportProgress(progress, milestones);
-    
-                const string query = "SELECT * FROM users WHERE username = @username";
-    await using var command = new MySqlCommand(query, connection);
-    command.Parameters.AddWithValue("@username", username);
-    
-    await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-                    {
-        throw new InvalidOperationException($"No configuration found for user '{username}'.");
-                    }
-    
-    sessionState.FirstName = GetString(reader, "Firstname");
-    sessionState.LastName = GetString(reader, "Lastname");
-    sessionState.Pin = GetString(reader, "Pin");
-    sessionState.AccountStatus = GetInt32(reader, "accountstatus");
-    ReportProgress(progress, milestones);
-    
-    sessionState.DragnetDatabase = new DatabaseCredentials(
-    GetString(reader, "DragnetIP"),
-    GetString(reader, "DragnetUser"),
-    GetString(reader, "DragnetPassword"),
-    GetString(reader, "DragnetDBName"),
-    GetInt32(reader, "DragnetPort1"),
-    GetInt32(reader, "DragnetPort2"));
-    sessionState.ControlDatabase = new DatabaseCredentials(
-    GetString(reader, "DragnetControlIP"),
-    GetString(reader, "DragnetControlUser"),
-    GetString(reader, "DragnetControlPassword"),
-    GetString(reader, "DragnetControlDBName"),
-    GetInt32(reader, "DragnetControlPort1"),
-    GetInt32(reader, "DragnetControlPort2"));
-    sessionState.AssetDatabase = new DatabaseCredentials(
-    GetString(reader, "AssetIP"),
-    GetString(reader, "assetuser"),
-    GetString(reader, "assetpw"),
-    GetString(reader, "assetDBName"),
-    GetInt32(reader, "assetPort1"),
-    GetInt32(reader, "assetPort2"));
-    sessionState.NewsDatabase = new DatabaseCredentials(
-    GetString(reader, "newsIP"),
-    GetString(reader, "newsuser"),
-    GetString(reader, "newspw"),
-    "newsdata",
-    GetInt32(reader, "newsport1"),
-    GetInt32(reader, "newsport2"));
-    sessionState.SocialMediaDatabase = new DatabaseCredentials(
-    GetString(reader, "SMIP"),
-    GetString(reader, "SMuser"),
-    GetString(reader, "smPW"),
-    GetOptionalString(reader, "SMDatabase") ?? string.Empty,
-    GetNullableInt32(reader, "SMPort1"),
-    GetNullableInt32(reader, "SMPort2"));
-    sessionState.TrendsDatabase = new DatabaseCredentials(
-    GetString(reader, "trendsip"),
-    GetString(reader, "trendsuser"),
-    GetString(reader, "trendsPW"),
-    GetOptionalString(reader, "trendsDatabase") ?? string.Empty,
-    GetNullableInt32(reader, "trendsPort1"),
-    GetNullableInt32(reader, "trendsPort2"));
-    
-    sessionState.DragnetDbConnectionString = sessionState.DragnetDatabase.BuildConnectionString();
-    sessionState.ControlDbConnectionString = sessionState.ControlDatabase.BuildConnectionString();
-    sessionState.AssetDbConnectionString = sessionState.AssetDatabase.BuildConnectionString();
-    sessionState.NewsDbConnectionString = sessionState.NewsDatabase.BuildConnectionString();
-    ReportProgress(progress, milestones);
-    
-    sessionState.CoinbaseScannerHost = GetString(reader, "CBScannerHost");
-    sessionState.CoinbaseScannerUser = GetString(reader, "CBScannerUser");
-    sessionState.CoinbaseScannerPassword = GetString(reader, "CBScannerPW");
-    sessionState.CoinbaseScannerPath = GetString(reader, "CBScannerPath");
-    sessionState.CoinbaseApiKey = GetString(reader, "coinbaseAPIKey");
-    sessionState.CoinbaseSecret = GetString(reader, "CoinbaseSecret");
-    sessionState.CoinbasePassphrase = GetString(reader, "CoinbasePassphrase");
-    sessionState.CoinbaseScannerPort1 = GetInt32(reader, "CBScannerPort1");
-    sessionState.CoinbaseScannerPort2 = GetInt32(reader, "CBScannerPort2");
-    sessionState.CryptoGranularity = GetInt32(reader, "CryptoGranularity");
-    sessionState.CryptoTimeSpan = GetFloat(reader, "CryptoTimeFrame");
-    sessionState.CryptoDelay = GetFloat(reader, "CryptoDelay");
-    
-    sessionState.TelegramHost = GetString(reader, "TelegramHost");
-    sessionState.TelegramUser = GetString(reader, "TelegramUser");
-    sessionState.TelegramPassword = GetString(reader, "TelegramPW");
-    sessionState.TelephoneNumber = GetString(reader, "TelephoneNumber");
-    sessionState.ScriptsPath = GetString(reader, "ScriptsPath");
-    sessionState.TelegramApiKey = GetString(reader, "TelegramAPIID");
-    sessionState.TelegramApiHash = GetString(reader, "TelegramAPIHash");
-    sessionState.TelegramDelay = GetInt32(reader, "TelegramDelay");
-    sessionState.TelegramTimespan = GetInt32(reader, "TelegramTimespan");
-    
-    sessionState.CurationDelayTime = GetInt32(reader, "CurationDelayTime");
-    sessionState.CurationHistoryTime = GetDecimal(reader, "CurationHistoryTime");
-    sessionState.CuratorPath = GetString(reader, "CuratorPath");
-    
-    sessionState.KrakenScannerHost = GetString(reader, "KrakenHost");
-    sessionState.KrakenScannerUser = GetString(reader, "KrakenScannerUser");
-    sessionState.KrakenScannerPassword = GetString(reader, "KrakenScannerPW");
-    sessionState.KrakenScannerPort1 = GetInt32(reader, "KrakenScannerPort1");
-    sessionState.KrakenScannerPort2 = GetInt32(reader, "KrakenScannerPort2");
-    sessionState.KrakenPath = GetString(reader, "KrakenPath");
-    sessionState.KrakenApiKey = GetString(reader, "KrakenAPI");
-    sessionState.KrakenPrivateKey = GetString(reader, "KrakenPrivateKey");
-    
-    sessionState.BinanceHost = GetString(reader, "BinanceHost");
-    sessionState.BinanceUser = GetString(reader, "BinanceUser");
-    sessionState.BinancePassword = GetString(reader, "BinancePW");
-    sessionState.BinancePort1 = GetInt32(reader, "BinancePort1");
-    sessionState.BinancePort2 = GetInt32(reader, "BinancePort2");
-    sessionState.BinancePath = GetString(reader, "BinancePath");
-    sessionState.BinanceApi = GetString(reader, "BinanceAPI");
-    sessionState.BinanceSecret = GetString(reader, "BinanceSecret");
-    
-    sessionState.CongressImagesFilepath = GetString(reader, "CongressImagesFilePath");
-    sessionState.LlmHost = GetString(reader, "LLMHost");
-    sessionState.LlmPort = GetString(reader, "LLMPort");
-    sessionState.LlmModel = GetString(reader, "LLMModel");
-    sessionState.LlmContextWindow = GetInt32(reader, "LLMContextWindow");
-    sessionState.DataDumpIp = GetString(reader, "DataDumpIP");
-    sessionState.DataDumpUser = GetString(reader, "DataDumpUser");
-    sessionState.DataDumpPassword = GetString(reader, "DataDumpPassword");
-    sessionState.ActiveLlmPrompt = GetString(reader, "LLMPromptName");
-    sessionState.ActiveLlmPromptVersion = GetString(reader, "LLMPromptVersion");
-    
-    ReportProgress(progress, milestones);
-    
-    sessionState.TargetUrl = GetOptionalString(reader, "TargetURL");
-    sessionState.ActiveTitle = GetOptionalString(reader, "ActiveTitle");
-    sessionState.ActiveSuffix = GetOptionalString(reader, "ActiveSuffix");
-    
-    ReportProgress(progress, milestones, forceComplete: true);
-    
-                return sessionState;
+
+            progress?.Report(new ConfigurationProgress("Preparing to load user profile", 0));
+
+            await using var connection = new MySqlConnection(sessionState.UsersDbConnectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            ReportProgress(progress, milestones);
+
+            const string query = "SELECT * FROM users WHERE username = @username";
+            await using var command = new MySqlCommand(query, connection);
+            command.Parameters.AddWithValue("@username", username);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException($"No configuration found for user '{username}'.");
             }
 
-        private static void ReportProgress(IProgress<ConfigurationProgress>? progress, Queue<(string Message, int Progress)> milestones, bool forceComplete = false)
+            sessionState.FirstName = GetString(reader, "Firstname");
+            sessionState.LastName = GetString(reader, "Lastname");
+            sessionState.Pin = GetString(reader, "Pin");
+            sessionState.AccountStatus = GetInt32(reader, "accountstatus");
+            ReportProgress(progress, milestones);
+
+            sessionState.DragnetDatabase = new DatabaseCredentials(
+                GetString(reader, "DragnetIP"),
+                GetString(reader, "DragnetUser"),
+                GetString(reader, "DragnetPassword"),
+                GetString(reader, "DragnetDBName"),
+                GetInt32(reader, "DragnetPort1"),
+                GetInt32(reader, "DragnetPort2"));
+            sessionState.ControlDatabase = new DatabaseCredentials(
+                GetString(reader, "DragnetControlIP"),
+                GetString(reader, "DragnetControlUser"),
+                GetString(reader, "DragnetControlPassword"),
+                GetString(reader, "DragnetControlDBName"),
+                GetInt32(reader, "DragnetControlPort1"),
+                GetInt32(reader, "DragnetControlPort2"));
+            sessionState.AssetDatabase = new DatabaseCredentials(
+                GetString(reader, "AssetIP"),
+                GetString(reader, "assetuser"),
+                GetString(reader, "assetpw"),
+                GetString(reader, "assetDBName"),
+                GetInt32(reader, "assetPort1"),
+                GetInt32(reader, "assetPort2"));
+            sessionState.NewsDatabase = new DatabaseCredentials(
+                GetString(reader, "newsIP"),
+                GetString(reader, "newsuser"),
+                GetString(reader, "newspw"),
+                "newsdata",
+                GetInt32(reader, "newsport1"),
+                GetInt32(reader, "newsport2"));
+            sessionState.SocialMediaDatabase = new DatabaseCredentials(
+                GetString(reader, "SMIP"),
+                GetString(reader, "SMuser"),
+                GetString(reader, "smPW"),
+                GetOptionalString(reader, "SMDatabase") ?? string.Empty,
+                GetNullableInt32(reader, "SMPort1"),
+                GetNullableInt32(reader, "SMPort2"));
+            sessionState.TrendsDatabase = new DatabaseCredentials(
+                GetString(reader, "trendsip"),
+                GetString(reader, "trendsuser"),
+                GetString(reader, "trendsPW"),
+                GetOptionalString(reader, "trendsDatabase") ?? string.Empty,
+                GetNullableInt32(reader, "trendsPort1"),
+                GetNullableInt32(reader, "trendsPort2"));
+
+            sessionState.DragnetDbConnectionString = sessionState.DragnetDatabase.BuildConnectionString();
+            sessionState.ControlDbConnectionString = sessionState.ControlDatabase.BuildConnectionString();
+            sessionState.AssetDbConnectionString = sessionState.AssetDatabase.BuildConnectionString();
+            sessionState.NewsDbConnectionString = sessionState.NewsDatabase.BuildConnectionString();
+            ReportProgress(progress, milestones);
+
+            sessionState.CoinbaseScannerHost = GetString(reader, "CBScannerHost");
+            sessionState.CoinbaseScannerUser = GetString(reader, "CBScannerUser");
+            sessionState.CoinbaseScannerPassword = GetString(reader, "CBScannerPW");
+            sessionState.CoinbaseScannerPath = GetString(reader, "CBScannerPath");
+            sessionState.CoinbaseApiKey = GetString(reader, "coinbaseAPIKey");
+            sessionState.CoinbaseSecret = GetString(reader, "CoinbaseSecret");
+            sessionState.CoinbasePassphrase = GetString(reader, "CoinbasePassphrase");
+            sessionState.CoinbaseScannerPort1 = GetInt32(reader, "CBScannerPort1");
+            sessionState.CoinbaseScannerPort2 = GetInt32(reader, "CBScannerPort2");
+            sessionState.CryptoGranularity = GetInt32(reader, "CryptoGranularity");
+            sessionState.CryptoTimeSpan = GetFloat(reader, "CryptoTimeFrame");
+            sessionState.CryptoDelay = GetFloat(reader, "CryptoDelay");
+
+            sessionState.TelegramHost = GetString(reader, "TelegramHost");
+            sessionState.TelegramUser = GetString(reader, "TelegramUser");
+            sessionState.TelegramPassword = GetString(reader, "TelegramPW");
+            sessionState.TelephoneNumber = GetString(reader, "TelephoneNumber");
+            sessionState.ScriptsPath = GetString(reader, "ScriptsPath");
+            sessionState.TelegramApiKey = GetString(reader, "TelegramAPIID");
+            sessionState.TelegramApiHash = GetString(reader, "TelegramAPIHash");
+            sessionState.TelegramDelay = GetInt32(reader, "TelegramDelay");
+            sessionState.TelegramTimespan = GetInt32(reader, "TelegramTimespan");
+
+            sessionState.CurationDelayTime = GetInt32(reader, "CurationDelayTime");
+            sessionState.CurationHistoryTime = GetDecimal(reader, "CurationHistoryTime");
+            sessionState.CuratorPath = GetString(reader, "CuratorPath");
+
+            sessionState.KrakenScannerHost = GetString(reader, "KrakenHost");
+            sessionState.KrakenScannerUser = GetString(reader, "KrakenScannerUser");
+            sessionState.KrakenScannerPassword = GetString(reader, "KrakenScannerPW");
+            sessionState.KrakenScannerPort1 = GetInt32(reader, "KrakenScannerPort1");
+            sessionState.KrakenScannerPort2 = GetInt32(reader, "KrakenScannerPort2");
+            sessionState.KrakenPath = GetString(reader, "KrakenPath");
+            sessionState.KrakenApiKey = GetString(reader, "KrakenAPI");
+            sessionState.KrakenPrivateKey = GetString(reader, "KrakenPrivateKey");
+
+            sessionState.BinanceHost = GetString(reader, "BinanceHost");
+            sessionState.BinanceUser = GetString(reader, "BinanceUser");
+            sessionState.BinancePassword = GetString(reader, "BinancePW");
+            sessionState.BinancePort1 = GetInt32(reader, "BinancePort1");
+            sessionState.BinancePort2 = GetInt32(reader, "BinancePort2");
+            sessionState.BinancePath = GetString(reader, "BinancePath");
+            sessionState.BinanceApi = GetString(reader, "BinanceAPI");
+            sessionState.BinanceSecret = GetString(reader, "BinanceSecret");
+
+            sessionState.CongressImagesFilepath = GetString(reader, "CongressImagesFilePath");
+            sessionState.LlmHost = GetString(reader, "LLMHost");
+            sessionState.LlmPort = GetString(reader, "LLMPort");
+            sessionState.LlmModel = GetString(reader, "LLMModel");
+            sessionState.LlmContextWindow = GetInt32(reader, "LLMContextWindow");
+            sessionState.DataDumpIp = GetString(reader, "DataDumpIP");
+            sessionState.DataDumpUser = GetString(reader, "DataDumpUser");
+            sessionState.DataDumpPassword = GetString(reader, "DataDumpPassword");
+            sessionState.ActiveLlmPrompt = GetString(reader, "LLMPromptName");
+            sessionState.ActiveLlmPromptVersion = GetString(reader, "LLMPromptVersion");
+
+            ReportProgress(progress, milestones);
+
+            sessionState.TargetUrl = GetOptionalString(reader, "TargetURL");
+            sessionState.ActiveTitle = GetOptionalString(reader, "ActiveTitle");
+            sessionState.ActiveSuffix = GetOptionalString(reader, "ActiveSuffix");
+
+            ReportProgress(progress, milestones, forceComplete: true);
+
+            return sessionState;
+        }
+
+        private static void ReportProgress(
+            IProgress<ConfigurationProgress>? progress,
+            Queue<(string Message, int Progress)> milestones,
+            bool forceComplete = false)
         {
-                if (progress == null)
-                    {
-                        return;
-                    }
-    
-                if (forceComplete)
-                    {
-        progress.Report(new ConfigurationProgress("Configuration loaded", 100));
-                        return;
-                    }
-    
-                if (milestones.Count == 0)
-                    {
-                        return;
-                    }
-    
-    var milestone = milestones.Dequeue();
-    progress.Report(new ConfigurationProgress(milestone.Message, milestone.Progress));
+            if (progress == null)
+            {
+                return;
             }
+
+            if (forceComplete)
+            {
+                progress.Report(new ConfigurationProgress("Configuration loaded", 100));
+                return;
+            }
+
+            if (milestones.Count == 0)
+            {
+                return;
+            }
+
+            var milestone = milestones.Dequeue();
+            progress.Report(new ConfigurationProgress(milestone.Message, milestone.Progress));
+        }
 
         private static string GetString(MySqlDataReader reader, string column)
         {
-                if (!TryGetOrdinal(reader, column, out var ordinal))
-                    {
-        throw new InvalidOperationException($"Required column '{column}' was not returned by the query.");
-                    }
-    
-                if (reader.IsDBNull(ordinal))
-                    {
-        throw new InvalidOperationException($"Column '{column}' contained NULL but a value was required.");
-                    }
-    
-                return reader.GetString(ordinal);
+            if (!TryGetOrdinal(reader, column, out var ordinal))
+            {
+                throw new InvalidOperationException($"Required column '{column}' was not returned by the query.");
             }
+
+            if (reader.IsDBNull(ordinal))
+            {
+                throw new InvalidOperationException($"Column '{column}' contained NULL but a value was required.");
+            }
+
+            return reader.GetString(ordinal);
+        }
 
         private static string? GetOptionalString(MySqlDataReader reader, string column)
         {
-                if (!TryGetOrdinal(reader, column, out var ordinal))
-                    {
-                        return null;
-                    }
-    
-                return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+            if (!TryGetOrdinal(reader, column, out var ordinal))
+            {
+                return null;
             }
+
+            return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+        }
 
         private static int GetInt32(MySqlDataReader reader, string column)
         {
-                if (!TryGetOrdinal(reader, column, out var ordinal))
-                    {
-                        return 0;
-                    }
-    
-                return reader.IsDBNull(ordinal) ? 0 : reader.GetInt32(ordinal);
+            if (!TryGetOrdinal(reader, column, out var ordinal))
+            {
+                return 0;
             }
+
+            return reader.IsDBNull(ordinal) ? 0 : reader.GetInt32(ordinal);
+        }
 
         private static int? GetNullableInt32(MySqlDataReader reader, string column)
         {
-                if (!TryGetOrdinal(reader, column, out var ordinal))
-                    {
-                        return null;
-                    }
-    
-                return reader.IsDBNull(ordinal) ? null : reader.GetInt32(ordinal);
+            if (!TryGetOrdinal(reader, column, out var ordinal))
+            {
+                return null;
             }
+
+            return reader.IsDBNull(ordinal) ? null : reader.GetInt32(ordinal);
+        }
 
         private static float GetFloat(MySqlDataReader reader, string column)
         {
-                if (!TryGetOrdinal(reader, column, out var ordinal))
-                    {
-                        return 0f;
-                    }
-    
-                return reader.IsDBNull(ordinal) ? 0 : reader.GetFloat(ordinal);
+            if (!TryGetOrdinal(reader, column, out var ordinal))
+            {
+                return 0f;
             }
+
+            return reader.IsDBNull(ordinal) ? 0 : reader.GetFloat(ordinal);
+        }
 
         private static decimal GetDecimal(MySqlDataReader reader, string column)
         {
-                if (!TryGetOrdinal(reader, column, out var ordinal))
-                    {
-                        return 0m;
-                    }
-    
-                return reader.IsDBNull(ordinal) ? 0 : reader.GetDecimal(ordinal);
+            if (!TryGetOrdinal(reader, column, out var ordinal))
+            {
+                return 0m;
             }
+
+            return reader.IsDBNull(ordinal) ? 0 : reader.GetDecimal(ordinal);
+        }
 
         private static bool TryGetOrdinal(MySqlDataReader reader, string column, out int ordinal)
         {
-                try
+            try
             {
-        ordinal = reader.GetOrdinal(column);
-                        return true;
-                    }
-                catch (IndexOutOfRangeException)
+                ordinal = reader.GetOrdinal(column);
+                return true;
+            }
+            catch (IndexOutOfRangeException)
             {
-        ordinal = -1;
-                        return false;
-                    }
+                ordinal = -1;
+                return false;
             }
         }
+    }
 }

--- a/Configuration/DatabaseCredentials.cs
+++ b/Configuration/DatabaseCredentials.cs
@@ -1,4 +1,7 @@
-﻿namespace DragnetControl.Configuration
+using System;
+using MySqlConnector;
+
+namespace DragnetControl.Configuration
 {
     public sealed class DatabaseCredentials
     {
@@ -27,7 +30,20 @@
 
         public string BuildConnectionString()
         {
-                return $"server={Host};uid={Username};password={Password};database={Database}";
+            var builder = new MySqlConnectionStringBuilder
+            {
+                Server = Host,
+                UserID = Username,
+                Password = Password,
+                Database = Database,
+            };
+
+            if (PrimaryPort.HasValue && PrimaryPort.Value > 0)
+            {
+                builder.Port = (uint)PrimaryPort.Value;
             }
+
+            return builder.ConnectionString;
+        }
     }
 }

--- a/Configuration/DatabaseSettings.cs
+++ b/Configuration/DatabaseSettings.cs
@@ -1,6 +1,3 @@
-﻿using DragnetControl.Configuration;
-using System.Configuration;
-using System.Xml.Linq;
 using System;
 using System.Configuration;
 
@@ -13,7 +10,7 @@ namespace DragnetControl.Configuration
     public sealed class DatabaseSettings
     {
         private static readonly Lazy<DatabaseSettings> _instance =
-new Lazy<DatabaseSettings>(() => new DatabaseSettings());
+            new Lazy<DatabaseSettings>(() => new DatabaseSettings());
 
         private DatabaseSettings()
         {
@@ -38,22 +35,22 @@ new Lazy<DatabaseSettings>(() => new DatabaseSettings());
 
         private static string ReadConnectionString(string name)
         {
-    var settings = ConfigurationManager.ConnectionStrings[name];
-                if (settings == null || string.IsNullOrWhiteSpace(settings.ConnectionString))
-                    {
-        throw new ConfigurationErrorsException(
-        $"Connection string '{name}' is not configured in App.config.");
-                    }
-    
-                return settings.ConnectionString;
+            var settings = ConfigurationManager.ConnectionStrings[name];
+            if (settings == null || string.IsNullOrWhiteSpace(settings.ConnectionString))
+            {
+                throw new ConfigurationErrorsException(
+                    $"Connection string '{name}' is not configured in App.config.");
             }
+
+            return settings.ConnectionString;
+        }
 
         private static string? ReadOptionalConnectionString(string name)
         {
-    var settings = ConfigurationManager.ConnectionStrings[name];
-                return string.IsNullOrWhiteSpace(settings?.ConnectionString)
-                    ? null
-                    : settings.ConnectionString;
-            }
+            var settings = ConfigurationManager.ConnectionStrings[name];
+            return string.IsNullOrWhiteSpace(settings?.ConnectionString)
+                ? null
+                : settings.ConnectionString;
+        }
     }
 }

--- a/Configuration/DragnetConfiguration.cs
+++ b/Configuration/DragnetConfiguration.cs
@@ -1,6 +1,5 @@
-﻿using DragnetControl.Configuration;
-
 using System;
+using System.Configuration;
 
 namespace DragnetControl.Configuration
 {
@@ -15,17 +14,26 @@ namespace DragnetControl.Configuration
 
         public static DragnetConfiguration FromAppConfig()
         {
-    var host = ReadSetting("DRAGNET_USERSDB_HOST") ?? "localhost";
-    var username = ReadSetting("DRAGNET_USERSDB_USER") ?? "dragnet";
-    var password = ReadSetting("DRAGNET_USERSDB_PASSWORD") ?? "dragnet5";
-    var database = ReadSetting("DRAGNET_USERSDB_NAME") ?? "userdata";
-    
-                return new DragnetConfiguration(new DatabaseCredentials(host, username, password, database));
-            }
+            var host = ReadSetting("DRAGNET_USERSDB_HOST") ?? ReadAppSetting("UsersDbHost") ?? "localhost";
+            var username = ReadSetting("DRAGNET_USERSDB_USER") ?? ReadAppSetting("UsersDbUser") ?? "dragnet";
+            var password = ReadSetting("DRAGNET_USERSDB_PASSWORD") ?? ReadAppSetting("UsersDbPassword") ?? "dragnet5";
+            var database = ReadSetting("DRAGNET_USERSDB_NAME") ?? ReadAppSetting("UsersDbName") ?? "userdata";
 
-        private static string? ReadSetting(string key)
+            return new DragnetConfiguration(new DatabaseCredentials(host, username, password, database));
+        }
+
+        private static string? ReadSetting(string key) => Environment.GetEnvironmentVariable(key);
+
+        private static string? ReadAppSetting(string key)
         {
-                return Environment.GetEnvironmentVariable(key);
+            try
+            {
+                return ConfigurationManager.AppSettings[key];
             }
+            catch (ConfigurationErrorsException)
+            {
+                return null;
+            }
+        }
     }
 }

--- a/Configuration/RuntimeSessionState.cs
+++ b/Configuration/RuntimeSessionState.cs
@@ -1,6 +1,3 @@
-﻿using DragnetControl.Configuration;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.StartPanel;
-using DragnetControl.Configuration;
 using System;
 
 namespace DragnetControl.Configuration
@@ -97,4 +94,3 @@ namespace DragnetControl.Configuration
         public string? ActiveSuffix { get; set; }
     }
 }
-

--- a/DragnetControl.csproj
+++ b/DragnetControl.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OpenQA.Selenium.Chrome.ChromeDriverExtensions" Version="1.2.0" />
     <PackageReference Include="OxyPlot.WindowsForms" Version="2.2.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
     <PackageReference Include="WinForms.DataVisualization" Version="1.10.0" />
   </ItemGroup>
 

--- a/FormManager.cs
+++ b/FormManager.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
 
 namespace DragnetControl
 {
-    public class FormManager
+    public static class FormManager
     {
-        private static MainControl _mainControl;
+        private static MainControl? _mainControl;
         private static Func<MainControl> _factory = () => new MainControl();
 
         public static MainControl MainControl
@@ -16,7 +12,6 @@ namespace DragnetControl
             get
             {
                 if (_mainControl == null || _mainControl.IsDisposed)
-
                 {
                     _mainControl = _factory();
                 }
@@ -32,11 +27,8 @@ namespace DragnetControl
             {
                 _mainControl.Dispose();
             }
+
             _mainControl = null;
         }
     }
 }
-       
-    
-
-    

--- a/PasswordChangeForm.Designer.cs
+++ b/PasswordChangeForm.Designer.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace YourNamespace
+namespace DragnetControl
 {
     partial class PasswordChangeForm
     {

--- a/PasswordChangeForm.cs
+++ b/PasswordChangeForm.cs
@@ -1,121 +1,102 @@
-﻿using System;
-using System.Data.SqlClient;
-using System.Linq;
+using System;
 using System.Windows.Forms;
+using DragnetControl.Configuration;
 using MySqlConnector;
-using BCrypt.Net;
+using BCryptNet = BCrypt.Net.BCrypt;
 
-namespace YourNamespace
+namespace DragnetControl
 {
     public partial class PasswordChangeForm : Form
     {
-        private string userName;
+        private readonly string _username;
+        private readonly DatabaseCredentials _credentials;
 
-        // Constructor that accepts the username
-        public PasswordChangeForm(string username)
+        public PasswordChangeForm(string username, DatabaseCredentials credentials)
         {
             InitializeComponent();
-            userName = username;
-            UsernameLabel.Text = "Username: " + userName;
+            _username = username ?? throw new ArgumentNullException(nameof(username));
+            _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+            UsernameLabel.Text = "Username: " + _username;
         }
 
         private void SubmitButton_Click(object sender, EventArgs e)
         {
             try
             {
-                string oldPassword = OldPasswordTextBox.Text;
-                string newPassword = NewPasswordTextBox.Text;
-                string newPassword2 = NewPasswordTextBox2.Text;
+                var oldPassword = OldPasswordTextBox.Text;
+                var newPassword = NewPasswordTextBox.Text;
+                var newPassword2 = NewPasswordTextBox2.Text;
 
-                // Validation logic here...
-
-                // Hash the new password
-                string newPasswordHash = BCrypt.Net.BCrypt.HashPassword(newPassword);
-
-                using (MySqlConnection conn = new MySqlConnection("server=localhost;uid=root;password=password;database=userdata"))
+                if (string.IsNullOrWhiteSpace(newPassword) || newPassword.Length < 8)
                 {
-                    conn.Open();
-
-                    // Verify the old password
-                    string query = "SELECT password FROM users WHERE Username = @username";
-                    using (MySqlCommand cmd = new MySqlCommand(query, conn))
-                    {
-                        cmd.Parameters.AddWithValue("@username", userName);
-                        using (MySqlDataReader reader = cmd.ExecuteReader())
-                        {
-                            if (reader.HasRows)
-                            {
-                                reader.Read();
-                                string storedPasswordHash = reader.GetString("Password");
-
-                                bool isVerified;
-                                if (storedPasswordHash.StartsWith("$2") && storedPasswordHash.Length == 60)
-                                {
-                                    // Verify BCrypt password
-                                    isVerified = BCrypt.Net.BCrypt.Verify(oldPassword, storedPasswordHash);
-                                }
-                                else
-                                {
-                                    // Verify plaintext password
-                                    isVerified = oldPassword == storedPasswordHash;
-                                }
-
-                                if (!isVerified)
-                                {
-                                    MessageLabel.Text = "The old password is incorrect.";
-                                    return;
-                                }
-                            }
-                            else
-                            {
-                                MessageLabel.Text = "The user does not exist.";
-                                return;
-                            }
-                        }
-                    }
-
-                    // Update the password
-                    string updateQuery = "UPDATE users SET Password = @newPassword WHERE username = @username";
-                    using (MySqlCommand updateCmd = new MySqlCommand(updateQuery, conn))
-                    {
-                        updateCmd.Parameters.AddWithValue("@newPassword", newPasswordHash);
-                        updateCmd.Parameters.AddWithValue("@username", userName);
-
-                        // Check how many rows were affected
-                        int rowsAffected = updateCmd.ExecuteNonQuery();
-                        if (rowsAffected > 0)
-                        {
-                            MessageLabel.Text = "Password changed successfully.";
-                        }
-                        else
-                        {
-                            MessageLabel.Text = "Password change failed. No rows were updated.";
-                        }
-                    }
+                    MessageLabel.Text = "New password must be at least 8 characters long.";
+                    return;
                 }
+
+                if (!string.Equals(newPassword, newPassword2, StringComparison.Ordinal))
+                {
+                    MessageLabel.Text = "New passwords do not match.";
+                    return;
+                }
+
+                var newPasswordHash = BCryptNet.HashPassword(newPassword);
+
+                using var conn = new MySqlConnection(_credentials.BuildConnectionString());
+                conn.Open();
+
+                const string query = "SELECT password FROM users WHERE Username = @username";
+                using var cmd = new MySqlCommand(query, conn);
+                cmd.Parameters.AddWithValue("@username", _username);
+
+                using var reader = cmd.ExecuteReader();
+                if (!reader.HasRows)
+                {
+                    MessageLabel.Text = "The user does not exist.";
+                    return;
+                }
+
+                reader.Read();
+                var storedPasswordHash = reader.GetString("Password");
+
+                var isVerified = storedPasswordHash.StartsWith("$2", StringComparison.Ordinal) && storedPasswordHash.Length == 60
+                    ? BCryptNet.Verify(oldPassword, storedPasswordHash)
+                    : string.Equals(oldPassword, storedPasswordHash, StringComparison.Ordinal);
+
+                if (!isVerified)
+                {
+                    MessageLabel.Text = "The old password is incorrect.";
+                    return;
+                }
+
+                reader.Close();
+
+                const string updateQuery = "UPDATE users SET Password = @newPassword WHERE username = @username";
+                using var updateCmd = new MySqlCommand(updateQuery, conn);
+                updateCmd.Parameters.AddWithValue("@newPassword", newPasswordHash);
+                updateCmd.Parameters.AddWithValue("@username", _username);
+
+                var rowsAffected = updateCmd.ExecuteNonQuery();
+                MessageLabel.Text = rowsAffected > 0
+                    ? "Password changed successfully."
+                    : "Password change failed. No rows were updated.";
             }
             catch (MySqlException ex)
             {
                 MessageLabel.Text = "An error occurred while changing the password: " + ex.Message;
-                Console.WriteLine("Error: " + ex.ToString());
             }
             catch (Exception ex)
             {
                 MessageLabel.Text = "An unexpected error occurred: " + ex.Message;
-                Console.WriteLine("Error: " + ex.ToString());
             }
         }
 
-
         private void PasswordChangeForm_Load(object sender, EventArgs e)
         {
-            // Load event logic, if needed
         }
 
         private void CloseLabel_Click(object sender, EventArgs e)
         {
-            this.Close();
+            Close();
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- rebuild the configuration loader, runtime session, and credential helpers to consistently populate connection details from app settings and environment variables
- harden the authentication flow for legacy hashes and reuse the shared database credentials when forcing a password change
- modernize the password change dialog and supporting utilities to use the shared configuration types and nullable-safe form manager

## Testing
- not run (dotnet SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2d3344e54833192f8b968cf7b7582